### PR TITLE
Updating object and tab metadata for API v42

### DIFF
--- a/src/applications/Object_Merge.app
+++ b/src/applications/Object_Merge.app
@@ -3,7 +3,7 @@
     <defaultLandingTab>standard-home</defaultLandingTab>
     <description>Object merge administration.</description>
     <label>Object Merge</label>
-    <tab>standard-Contact</tab>
-    <tab>Object_Merge_Handler__c</tab>
-    <tab>Object_Merge_Pair__c</tab>
+    <tabs>standard-Contact</tabs>
+    <tabs>Object_Merge_Handler__c</tabs>
+    <tabs>Object_Merge_Pair__c</tabs>
 </CustomApplication>

--- a/src/objects/Object_Merge_Pair__c.object
+++ b/src/objects/Object_Merge_Pair__c.object
@@ -96,25 +96,25 @@
         <externalId>false</externalId>
         <inlineHelpText>Status of the merge operation.</inlineHelpText>
         <label>Status</label>
-        <picklist>
-            <picklistValues>
-                <fullName>Merged</fullName>
-                <default>false</default>
-            </picklistValues>
-            <picklistValues>
-                <fullName>Error</fullName>
-                <default>false</default>
-            </picklistValues>
-            <picklistValues>
-                <fullName>Retry</fullName>
-                <default>false</default>
-            </picklistValues>
-            <restrictedPicklist>true</restrictedPicklist>
-            <sorted>false</sorted>
-        </picklist>
-        <required>false</required>
-        <trackTrending>false</trackTrending>
-        <type>Picklist</type>
+            <type>Picklist</type>
+            <valueSet>
+                <restricted>true</restricted>
+                <valueSetDefinition>
+                    <sorted>false</sorted>
+                    <value>
+                        <fullName>Merged</fullName>
+                        <default>false</default>
+                    </value>
+                    <value>
+                        <fullName>Error</fullName>
+                        <default>false</default>
+                    </value>
+                    <value>
+                        <fullName>Retry</fullName>
+                        <default>false</default>
+                    </value>
+                </valueSetDefinition>
+            </valueSet>
     </fields>
     <fields>
         <fullName>Victim_ID__c</fullName>


### PR DESCRIPTION
Just some minor metadata format changes so the package deploys cleanly on at least api v42.